### PR TITLE
Increase timeout

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -37,7 +37,7 @@ release = ''
 # If your documentation needs a minimal Sphinx version, state it here.
 #
 # needs_sphinx = '1.0'
-nbsphinx_timeout = 400
+nbsphinx_timeout = 600
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
Recently builds have been failing with a 
```
Command killed due to timeout or excessive memory consumption
```

<img width="809" alt="Screen Shot 2022-06-22 at 1 43 04 PM" src="https://user-images.githubusercontent.com/32295036/174999734-6ff82e07-a6c0-4a1c-ba33-1c07995d73e9.png">


This PR is to test whether increasing timeout will solve the problem. 
