### PR TITLE
fix broken asset link

### DIFF
--- a/nbs/data_augmentation_segmentation.ipynb
+++ b/nbs/data_augmentation_segmentation.ipynb
@@ -78,7 +78,7 @@
     "    return filename\n",
     "\n",
     "\n",
-    "url = \"http://www.zemris.fer.hr/~ssegvic/multiclod/images/causevic16semseg3.png\"\n",
+    "url = \"https://github.com/kornia/data/raw/main/causevic16semseg3.png\"\n",
     "download_image(url)"
    ]
   },


### PR DESCRIPTION
The tutorials CI on main repo and here is falling because the asset link is offline

link to: https://github.com/kornia/data/pull/7